### PR TITLE
feat(initializeBot): add dev role to new help thread text body

### DIFF
--- a/src/discord-bot/bot/initializeBot.ts
+++ b/src/discord-bot/bot/initializeBot.ts
@@ -16,6 +16,7 @@ import { channelUpdateHandler } from "./events/channelUpdate";
 import { guildRolesHandler } from "./events/guildRoles";
 import { BotLog } from "./utils";
 import { extractThreadData } from "./utils/help";
+import { derive } from "../../shared/utils";
 
 export const initializeBot = () => {
   discord.client?.once(Discord.Events.ClientReady, async () => {
@@ -78,15 +79,26 @@ export const initializeBot = () => {
 
       if (data) {
         const workItem = await azureSharedClient.createWorkItem(data);
+        const guildRole = await discord.role('dev');
+    
+        const content = derive(()=> {
+          const workItemLink = `Azure Work Item: https://dev.azure.com/ptbcp/IT.DIT/_workitems/edit/${workItem.id}`;
+          
+          if(guildRole) {
+            return `<@&${guildRole.id}> ${workItemLink}`
+          } else {
+            return workItemLink
+          }
+        })
 
         await thread.send({
-          content: `Azure Work Item: https://dev.azure.com/ptbcp/IT.DIT/_workitems/edit/${workItem.id}`,
+          content,
         });
 
         logger.db.discord({
           level: "info",
           message: JSON.stringify(
-            { title: "createWorkItem", payload: workItem.id },
+            { title: "createWorkItem",  payload: workItem.id },
             undefined,
             2
           ),

--- a/src/discord-bot/bot/initializeBot.ts
+++ b/src/discord-bot/bot/initializeBot.ts
@@ -98,7 +98,7 @@ export const initializeBot = () => {
         logger.db.discord({
           level: "info",
           message: JSON.stringify(
-            { title: "createWorkItem",  payload: workItem.id },
+            { title: "createWorkItem", payload: workItem.id },
             undefined,
             2
           ),

--- a/src/discord-bot/bot/initializeBot.ts
+++ b/src/discord-bot/bot/initializeBot.ts
@@ -79,15 +79,15 @@ export const initializeBot = () => {
 
       if (data) {
         const workItem = await azureSharedClient.createWorkItem(data);
-        const guildRole = await discord.role('dev');
+        const guildRole = discord.mention({ roles:'dev' });
     
         const content = derive(()=> {
           const workItemLink = `Azure Work Item: https://dev.azure.com/ptbcp/IT.DIT/_workitems/edit/${workItem.id}`;
-          
+
           if(guildRole) {
-            return `<@&${guildRole.id}> ${workItemLink}`
+            return `${guildRole} - ${workItemLink}`;
           } else {
-            return workItemLink
+            return workItemLink;
           }
         })
 


### PR DESCRIPTION
In order to include all relevant devs into help threads and avoid miscommunication with the labs I propose to add an embedded dev role into the text message left by the bot upon thread creation.